### PR TITLE
clear space on unmount

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -20,6 +20,15 @@ export class PtsCanvas extends React.Component {
     this._update();
   }
 
+  componentWillUnmount() {
+    // remove resize event listener (if any)
+    this.space.setup({ resize: false });
+    // stop animation loop
+    this.space.stop();
+    // remove player from space
+    this.space.removeAll();
+  }
+
   _update() {
     if (this.props.play) {
       this.space.play();

--- a/src/index.js
+++ b/src/index.js
@@ -21,12 +21,7 @@ export class PtsCanvas extends React.Component {
   }
 
   componentWillUnmount() {
-    // remove resize event listener (if any)
-    this.space.setup({ resize: false });
-    // stop animation loop
-    this.space.stop();
-    // remove player from space
-    this.space.removeAll();
+    this.space.dispose();
   }
 
   _update() {


### PR DESCRIPTION
Closes #16 

Hi @williamngan, this is a proposed fix to the resize listener not being cleared. I also had to remove the player from the space to get rid of its own resize function being called after unmount and causing no-ops.

And for good measure I'm also stopping the animation loop. Would it be stopped automatically? (see #17 for more context on that).

Let me know if you need any changes.