### PR TITLE
Add playerRef to update state changes within handlers

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -132,7 +132,7 @@ const PtsCanvasComponent = (
     return () => {
       spaceRef.current && spaceRef.current.dispose()
     }
-  }, [canvRef, spaceRef, formRef])
+  }, [canvRef])
 
   /**
    * When onStart callback updates

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -5,8 +5,8 @@
  */
 
 /* eslint-disable  react/prop-types */
-import React, { useEffect, useRef, forwardRef, ForwardedRef } from 'react'
-import { CanvasSpace, Bound, CanvasForm, Group, Tempo } from 'pts'
+import React, { useEffect, useLayoutEffect, useRef, forwardRef, ForwardedRef } from 'react'
+import { CanvasSpace, Bound, CanvasForm, Group, Tempo, IPlayer } from 'pts'
 
 export type HandleStartFn = (
   bound: Bound,
@@ -77,11 +77,12 @@ const PtsCanvasComponent = (
   const canvRef = ref && typeof ref !== 'function' ? ref : useRef(null)
   const spaceRef = useRef<CanvasSpace>()
   const formRef = useRef<CanvasForm>()
+  const playerRef = useRef<IPlayer>()
 
   /**
    * When canvRef Updates (ready for space)
    */
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (!canvRef || !canvRef.current) return
     // Create CanvasSpace with the canvRef and assign to spaceRef
     // Add animation, tempo, and play when ready (call back on CanvasSpace constructor)
@@ -94,9 +95,8 @@ const PtsCanvasComponent = (
     // Assign formRef
     formRef.current = spaceRef.current.getForm()
 
-    // By having individual handler props, we can expose what we need to the
-    // underlying functions, like our Form instance
-    spaceRef.current.add({
+    // Player object
+    playerRef.current = {
       start: (bound: Bound) => {
         if (onStart && spaceRef.current && formRef.current) {
           onStart(bound, spaceRef.current, formRef.current)
@@ -117,7 +117,11 @@ const PtsCanvasComponent = (
           onAction(spaceRef.current, formRef.current, type, px, py, evt)
         }
       }
-    })
+    }
+
+    // By having individual handler props, we can expose what we need to the
+    // underlying functions, like our Form instance
+    spaceRef.current.add(playerRef.current)
 
     // Add tempo if provided
     if (tempo) {
@@ -128,7 +132,59 @@ const PtsCanvasComponent = (
     return () => {
       spaceRef.current && spaceRef.current.dispose()
     }
-  }, [canvRef])
+  }, [canvRef, spaceRef, formRef])
+
+  /**
+   * When onStart callback updates
+   */
+  useEffect(() => {
+    if (playerRef.current) {
+      playerRef.current.start = (bound: Bound) => {
+        if (onStart && spaceRef.current && formRef.current) {
+          onStart(bound, spaceRef.current, formRef.current)
+        }
+      }
+    }
+  }, [onStart])
+
+  /**
+   * When onAnimate callback updates
+   */
+  useEffect(() => {
+    if (playerRef.current) {
+      playerRef.current.animate = (time?: number, ftime?: number) => {
+        if (time && ftime && spaceRef.current && formRef.current) {
+          onAnimate(spaceRef.current, formRef.current, time, ftime)
+        }
+      }
+    }
+  }, [onAnimate])
+
+  /**
+   * When onResize callback updates
+   */
+  useEffect(() => {
+    if (playerRef.current) {
+      playerRef.current.resize = (bound: Bound, event: Event) => {
+        if (onResize && spaceRef.current && formRef.current) {
+          onResize(spaceRef.current, formRef.current, bound, event)
+        }
+      }
+    }
+  }, [onResize])
+
+  /**
+   * When onAction callback updates
+   */
+  useEffect(() => {
+    if (playerRef.current) {
+      playerRef.current.action = (type: string, px: number, py: number, evt: Event) => {
+        if (onAction && spaceRef.current && formRef.current) {
+          onAction(spaceRef.current, formRef.current, type, px, py, evt)
+        }
+      }
+    }
+  }, [onAction])
 
   /**
    * When Touch updates


### PR DESCRIPTION
Hey @tibotiber and @prkirby -- can you help me review this change? I discovered that the `onAnimate` handler couldn't get updated state variables because (I think) the callback handlers weren't part of `useEffect` dependencies.

Here I introduced a `playerRef` so that we can keep track of changes in onAnimate etc. Does it make sense? OR are there better ways to fix this? 

Appreciate your help on this! Here's an example component for testing: 

```jsx
export const AnimationExample = ({name, background, play}) => {
  const [noiseGrid, setNoiseGrid]  = useState([]);

  const handleStart = useCallback((bound, space) => {
    const gd = Create.gridPts( space.innerBound, 20, 20 );
    setNoiseGrid( Create.noisePts( gd, 0.05, 0.1, 20, 20 ) );
  }, [setNoiseGrid]);

  const handleAnimate = useCallback((space, form, time) => {
    if (!space) return;
    // Use pointer position to change speed
    const speed = space.pointer.$subtract( space.center ).divide( space.center ).abs();

    // Generate noise in a grid
    noiseGrid.forEach( (p) => {
      p.step( 0.01*(1-speed.x), 0.01*(1-speed.y) );
      form.fillOnly("#123").point( p, Math.abs( p.noise2D() * space.size.x/18 ), "circle" );
    });
  }, [noiseGrid]);

  return (
    <PtsCanvas
      name={name}
      background={background}
      play={play}
      onStart={handleStart}
      onAnimate={handleAnimate}
    />
  );
}
```
